### PR TITLE
added pitfalls for language selection during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ One should see the following screenshots for further configuration.
 | :---: |
 |**Figure 0.0** |
 
+Make sure you select `한국어` instead of `English` at this step. Otherwise Korean fonts won't work, even with `NanumGothic` or `NanumBarunGothic` fix shown later.
 |![01png](images/selectko.png)|
 | :---: |
 |**Figure 0.1** |


### PR DESCRIPTION
Adding a small addition to README.md regarding language choice for clarity.

Installation with English results in an unexpected result; setting the font to `NanumGothic` or `NanumBarunGothic` would not fix the issue where Korean texts appearing as boxes.

Thanks again for the awesome project :)